### PR TITLE
refactor: mapproxy will able to convert image type to mapproxy image format (MAPCO-2762)

### DIFF
--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -295,8 +295,8 @@ components:
         format:
           type: string
           enum:
-            - image/png
-            - image/jpeg
+            - PNG
+            - JPEG
     getLayerResponse:
       type: object
       required:

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@map-colonies/error-types": "^1.1.3",
         "@map-colonies/express-access-log-middleware": "^0.0.3",
         "@map-colonies/js-logger": "^0.0.3",
+        "@map-colonies/mc-model-types": "^14.0.0",
         "@map-colonies/openapi-express-viewer": "^2.0.1",
         "@map-colonies/read-pkg": "0.0.1",
         "@map-colonies/telemetry": "3.0.0",
@@ -2897,6 +2898,15 @@
         "pino-pretty": "^4.7.1"
       }
     },
+    "node_modules/@map-colonies/mc-model-types": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@map-colonies/mc-model-types/-/mc-model-types-14.0.0.tgz",
+      "integrity": "sha512-5uTiBZ5/JlG3Nvjs0/V0DYnGK5QxxSg9ieLIK4PBIzJ2liZx83bOwbGODsKzkquosHRY2nhtB7qmvAgz1xpOLQ==",
+      "dependencies": {
+        "@types/geojson": "^7946.0.7",
+        "reflect-metadata": "^0.1.13"
+      }
+    },
     "node_modules/@map-colonies/openapi-express-viewer": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@map-colonies/openapi-express-viewer/-/openapi-express-viewer-2.0.1.tgz",
@@ -3661,6 +3671,11 @@
         "@types/qs": "*",
         "@types/range-parser": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.10",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
+      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA=="
     },
     "node_modules/@types/glob": {
       "version": "7.2.0",
@@ -16520,6 +16535,15 @@
         "pino-pretty": "^4.7.1"
       }
     },
+    "@map-colonies/mc-model-types": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@map-colonies/mc-model-types/-/mc-model-types-14.0.0.tgz",
+      "integrity": "sha512-5uTiBZ5/JlG3Nvjs0/V0DYnGK5QxxSg9ieLIK4PBIzJ2liZx83bOwbGODsKzkquosHRY2nhtB7qmvAgz1xpOLQ==",
+      "requires": {
+        "@types/geojson": "^7946.0.7",
+        "reflect-metadata": "^0.1.13"
+      }
+    },
     "@map-colonies/openapi-express-viewer": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@map-colonies/openapi-express-viewer/-/openapi-express-viewer-2.0.1.tgz",
@@ -17122,6 +17146,11 @@
         "@types/qs": "*",
         "@types/range-parser": "*"
       }
+    },
+    "@types/geojson": {
+      "version": "7946.0.10",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
+      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA=="
     },
     "@types/glob": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@map-colonies/error-types": "^1.1.3",
     "@map-colonies/express-access-log-middleware": "^0.0.3",
     "@map-colonies/js-logger": "^0.0.3",
+    "@map-colonies/mc-model-types": "^14.0.0",
     "@map-colonies/openapi-express-viewer": "^2.0.1",
     "@map-colonies/read-pkg": "0.0.1",
     "@map-colonies/telemetry": "3.0.0",

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { PoolClient } from 'pg';
 import { JsonObject } from 'swagger-ui-express';
+import { TileOutputFormat } from '@map-colonies/mc-model-types';
 import { Providers, TileFormat } from './enums';
 
 export interface IConfig {
@@ -119,7 +120,7 @@ export interface ILayerPostRequest {
   name: string;
   tilesPath: string;
   cacheType: string;
-  format: TileFormat;
+  format: TileOutputFormat;
 }
 
 export interface ILayerToMosaicRequest {

--- a/src/layers/models/layersManager.ts
+++ b/src/layers/models/layersManager.ts
@@ -48,8 +48,8 @@ class LayersManager {
       if (isLayerNameExists(jsonDocument, layerRequest.name)) {
         throw new ConflictError(`Layer name '${layerRequest.name}' is already exists`);
       }
-
-      const newCache: IMapProxyCache = this.getCacheValues(layerRequest.cacheType, layerRequest.tilesPath, this.mapToTileFormat(layerRequest.format));
+      const tileFormat = this.mapToTileFormat(layerRequest.format);
+      const newCache: IMapProxyCache = this.getCacheValues(layerRequest.cacheType, layerRequest.tilesPath, tileFormat);
       const newLayer: IMapProxyLayer = this.getLayerValues(layerRequest.name);
       jsonDocument.caches[layerRequest.name] = newCache;
       jsonDocument.layers.push(newLayer);
@@ -146,7 +146,8 @@ class LayersManager {
 
   public async updateLayer(layerName: string, layerRequest: ILayerPostRequest): Promise<void> {
     this.logger.info(`Update layer: '${layerName}' request`);
-    const newCache: IMapProxyCache = this.getCacheValues(layerRequest.cacheType, layerRequest.tilesPath, this.mapToTileFormat(layerRequest.format));
+    const tileFormat = this.mapToTileFormat(layerRequest.format);
+    const newCache: IMapProxyCache = this.getCacheValues(layerRequest.cacheType, layerRequest.tilesPath, tileFormat);
     const newLayer: IMapProxyLayer = this.getLayerValues(layerName);
 
     const editJson = (jsonDocument: IMapProxyJsonDocument): IMapProxyJsonDocument => {

--- a/tests/integration/layers/layersManager.spec.ts
+++ b/tests/integration/layers/layersManager.spec.ts
@@ -3,6 +3,7 @@ import jsLogger from '@map-colonies/js-logger';
 import { trace } from '@opentelemetry/api';
 import config from 'config';
 import { container } from 'tsyringe';
+import { TileOutputFormat } from '@map-colonies/mc-model-types';
 import {
   IFSConfig,
   ILayerPostRequest,
@@ -20,7 +21,6 @@ import { getApp } from '../../../src/app';
 import { SERVICES } from '../../../src/common/constants';
 import { layersRouterFactory, LAYERS_ROUTER_SYMBOL } from '../../../src/layers/routes/layersRouterFactory';
 import { LayersRequestSender } from '../layers/helpers/requestSender';
-import { TileFormat } from '../../../src/common/enums';
 
 let requestSender: LayersRequestSender;
 describe('layerManager', () => {
@@ -121,7 +121,7 @@ describe('layerManager', () => {
       name: 'amsterdam_5cm',
       tilesPath: '/path/to/tiles/directory/in/my/bucket/',
       cacheType: 's3',
-      format: TileFormat.JPEG,
+      format: TileOutputFormat.JPEG,
     };
 
     it('Happy Path - should return status 202', async () => {

--- a/tests/unit/layers/models/layersManager.spec.ts
+++ b/tests/unit/layers/models/layersManager.spec.ts
@@ -2,6 +2,7 @@ import { normalize } from 'path';
 import { container } from 'tsyringe';
 import jsLogger from '@map-colonies/js-logger';
 import { ConflictError, NotFoundError } from '@map-colonies/error-types';
+import { TileOutputFormat } from '@map-colonies/mc-model-types';
 import { ILayerPostRequest, ILayerToMosaicRequest, IMapProxyCache, IMapProxyConfig, IUpdateMosaicRequest } from '../../../../src/common/interfaces';
 import { LayersManager } from '../../../../src/layers/models/layersManager';
 import { mockLayerNameAlreadyExists } from '../../mock/mockLayerNameAlreadyExists';
@@ -10,7 +11,6 @@ import * as utils from '../../../../src/common/utils';
 import { MockConfigProvider, getJsonMock, updateJsonMock, init as initConfigProvider } from '../../mock/mockConfigProvider';
 import { SERVICES } from '../../../../src/common/constants';
 import { registerTestValues } from '../../../integration/testContainerConfig';
-import { TileFormat } from '../../../../src/common/enums';
 
 let layersManager: LayersManager;
 let sortArrayByZIndexStub: jest.SpyInstance;
@@ -218,7 +218,7 @@ describe('layersManager', () => {
       name: 'amsterdam_5cm',
       tilesPath: '/path/to/tiles/directory/in/my/bucket/',
       cacheType: 's3',
-      format: TileFormat.JPEG,
+      format: TileOutputFormat.JPEG,
     };
 
     it('should successfully update layer', async () => {

--- a/tests/unit/mock/mockLayerNameAlreadyExists.ts
+++ b/tests/unit/mock/mockLayerNameAlreadyExists.ts
@@ -1,4 +1,4 @@
-import { TileFormat } from '../../../src/common/enums';
+import { TileOutputFormat } from '@map-colonies/mc-model-types';
 import { ILayerPostRequest } from '../../../src/common/interfaces';
 
 //TODO: remove mock data after contollers implementaion
@@ -7,5 +7,5 @@ export const mockLayerNameAlreadyExists: ILayerPostRequest = {
   name: 'NameIsAlreadyExists',
   tilesPath: '/path/to/s3/directory/tile',
   cacheType: 's3',
-  format: TileFormat.JPEG,
+  format: TileOutputFormat.JPEG,
 };

--- a/tests/unit/mock/mockLayerNameIsNotExists.ts
+++ b/tests/unit/mock/mockLayerNameIsNotExists.ts
@@ -1,4 +1,4 @@
-import { TileFormat } from '../../../src/common/enums';
+import { TileOutputFormat } from '@map-colonies/mc-model-types';
 import { ILayerPostRequest } from '../../../src/common/interfaces';
 
 //TODO: remove mock data after contollers implementaion
@@ -7,5 +7,5 @@ export const mockLayerNameIsNotExists: ILayerPostRequest = {
   name: 'NameIsNotExists',
   tilesPath: '/path/to/s3/directory/tile',
   cacheType: 's3',
-  format: TileFormat.JPEG,
+  format: TileOutputFormat.JPEG,
 };


### PR DESCRIPTION


| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✔                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✔                                                                       |

mapproxy api will convert from the request the image type into image format "image/image-type" instead getting from request