### PR TITLE
feat: adding api retrieve current mapproxy yaml configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -7,6 +7,38 @@ info:
     name: MIT
     url: https://opensource.org/licenses/MIT
 paths:
+  /config:
+    get:
+      operationId: getConfig
+      tags:
+        - Config
+      summary: get current mapproxy config
+      responses:
+        '200':
+          description: OK
+          content:
+            application/yaml:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/getConfigResponse'
+                  - $ref: '#/components/schemas/getConfigYamlResponse'
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/getConfigResponse'
+                  - $ref: '#/components/schemas/getConfigYamlResponse'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        '500':
+          description: Ineternal Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
   /layer:
     post:
       operationId: addLayer
@@ -330,6 +362,85 @@ components:
           enum:
             - image/png
             - image/jpeg
+    getConfigResponse:
+      type: object
+      properties:
+        grids:
+          type: object
+          properties:
+            grid:
+              type: object
+              properties:
+                name:
+                  type: string
+                srs:
+                  type: string
+                origin:
+                  type: string
+                min_res:
+                  type: number
+                num_levels:
+                  type: number
+                bbox:
+                  type: array
+                  items:
+                    type: number
+        caches:
+          type: object
+          properties:
+            cache:
+              type: object
+              properties:
+                type:
+                  type: string
+                directory:
+                  type: string
+                directory_layout:
+                  type: string
+                grids:
+                  type: array
+                  items:
+                    type: string
+                format:
+                  type: string
+                  enum:
+                    - image/png
+                    - image/jpeg
+                sources:
+                  type: array
+                  items:
+                    type: string
+                upscale_tiles:
+                  type: number
+                minimize_meta_request:
+                  type: boolean
+        layers:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              title:
+                type: string
+              sources:
+                type: array
+                items:
+                  type: string
+        globals:
+          type: object
+          properties:
+            cache:
+              type: object
+            image:
+              type: object
+        sources:
+          type: object
+        services:
+          type: object
+    getConfigYamlResponse:
+      type: string
+
     mosaicLayer:
       type: object
       required:

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@opentelemetry/api-metrics": "0.23.0",
         "@opentelemetry/instrumentation-express": "0.32.1",
         "@opentelemetry/instrumentation-http": "0.35.1",
-        "@types/js-yaml": "^3.12.5",
+        "@types/js-yaml": "^3.12.10",
         "aws-sdk": "^2.1107.0",
         "compression": "^1.7.4",
         "config": "^3.3.9",
@@ -108,14 +108,87 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.18.6",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.18.6"
+        "@babel/highlight": "^7.23.4",
+        "chalk": "^2.4.2"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@babel/compat-data": {
@@ -156,9 +229,10 @@
       }
     },
     "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -189,20 +263,23 @@
       }
     },
     "node_modules/@babel/eslint-parser/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.18.12",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+      "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.18.10",
+        "@babel/types": "^7.23.6",
         "@jridgewell/gen-mapping": "^0.3.2",
+        "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
       },
       "engines": {
@@ -263,9 +340,10 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -322,17 +400,19 @@
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.18.9",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -349,23 +429,25 @@
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.18.9",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.18.6",
-        "@babel/types": "^7.18.9"
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.23.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.18.6",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.18.6"
+        "@babel/types": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -485,28 +567,31 @@
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.18.6",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.18.6"
+        "@babel/types": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.21.5",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+      "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.19.1",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -547,12 +632,13 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.18.6",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.18.6",
-        "chalk": "^2.0.0",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
       "engines": {
@@ -561,8 +647,9 @@
     },
     "node_modules/@babel/highlight/node_modules/ansi-styles": {
       "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -572,8 +659,9 @@
     },
     "node_modules/@babel/highlight/node_modules/chalk": {
       "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -585,37 +673,42 @@
     },
     "node_modules/@babel/highlight/node_modules/color-convert": {
       "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
       }
     },
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@babel/highlight/node_modules/has-flag": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/@babel/highlight/node_modules/supports-color": {
       "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -624,9 +717,10 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.21.8",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+      "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -1651,9 +1745,10 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -1863,9 +1958,10 @@
       }
     },
     "node_modules/@babel/preset-env/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -1943,32 +2039,34 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.18.10",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.18.6",
-        "@babel/parser": "^7.18.10",
-        "@babel/types": "^7.18.10"
+        "@babel/code-frame": "^7.22.13",
+        "@babel/parser": "^7.22.15",
+        "@babel/types": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.18.11",
+      "version": "7.23.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.7.tgz",
+      "integrity": "sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.18.10",
-        "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-function-name": "^7.18.9",
-        "@babel/helper-hoist-variables": "^7.18.6",
-        "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.18.11",
-        "@babel/types": "^7.18.10",
-        "debug": "^4.1.0",
+        "@babel/code-frame": "^7.23.5",
+        "@babel/generator": "^7.23.6",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
+        "@babel/helper-hoist-variables": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/parser": "^7.23.6",
+        "@babel/types": "^7.23.6",
+        "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
       "engines": {
@@ -1984,12 +2082,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.21.5",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
+      "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.21.5",
-        "@babel/helper-validator-identifier": "^7.19.1",
+        "@babel/helper-string-parser": "^7.23.4",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -2112,12 +2211,13 @@
       }
     },
     "node_modules/@commitlint/is-ignored": {
-      "version": "17.6.3",
+      "version": "17.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.8.1.tgz",
+      "integrity": "sha512-UshMi4Ltb4ZlNn4F7WtSEugFDZmctzFpmbqvpyxD3la510J+PLcnyhf9chs7EryaRFJMdAKwsEKfNK0jL/QM4g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^17.4.4",
-        "semver": "7.5.0"
+        "@commitlint/types": "^17.8.1",
+        "semver": "7.5.4"
       },
       "engines": {
         "node": ">=v14"
@@ -2281,9 +2381,10 @@
       }
     },
     "node_modules/@commitlint/types": {
-      "version": "17.4.4",
+      "version": "17.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-17.8.1.tgz",
+      "integrity": "sha512-PXDQXkAmiMEG162Bqdh9ChML/GJZo6vU+7F03ALKDK8zYc6SuAr47LjG7hGYRqUOz+WK0dU7bQ0xzuqFMdxzeQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0"
       },
@@ -3011,12 +3112,12 @@
       }
     },
     "node_modules/@map-colonies/mc-utils/node_modules/axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.5.tgz",
+      "integrity": "sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==",
       "peer": true,
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -7244,8 +7345,9 @@
       }
     },
     "node_modules/@types/js-yaml": {
-      "version": "3.12.7",
-      "license": "MIT"
+      "version": "3.12.10",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.10.tgz",
+      "integrity": "sha512-/Mtaq/wf+HxXpvhzFYzrzCqNRcA958sW++7JOFC8nPrZcvfi/TrzOaaGbvt27ltJB2NQbHVAg5a1wUCsyMH7NA=="
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
@@ -8073,9 +8175,10 @@
       }
     },
     "node_modules/assert-node-version/node_modules/semver": {
-      "version": "5.7.1",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
@@ -8133,8 +8236,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1189.0",
-      "license": "Apache-2.0",
+      "version": "2.1536.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1536.0.tgz",
+      "integrity": "sha512-Kwl5xKti6qURwKkasZPA9d4q72tcNt0e3ZZ2ikjZvWbfWcIuuLN0GpUTarU8UpV4EiEw3W5z5G3jyHy8JLNyLw==",
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -8145,7 +8249,7 @@
         "url": "0.10.3",
         "util": "^0.12.4",
         "uuid": "8.0.0",
-        "xml2js": "0.4.19"
+        "xml2js": "0.5.0"
       },
       "engines": {
         "node": ">= 10.0.0"
@@ -8267,9 +8371,10 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -8503,7 +8608,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.3",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
+      "integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
       "dev": true,
       "funding": [
         {
@@ -8513,14 +8620,17 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001370",
-        "electron-to-chromium": "^1.4.202",
-        "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.5"
+        "caniuse-lite": "^1.0.30001565",
+        "electron-to-chromium": "^1.4.601",
+        "node-releases": "^2.0.14",
+        "update-browserslist-db": "^1.0.13"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -8647,7 +8757,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001374",
+      "version": "1.0.30001576",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz",
+      "integrity": "sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==",
       "dev": true,
       "funding": [
         {
@@ -8657,9 +8769,12 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
-      ],
-      "license": "CC-BY-4.0"
+      ]
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -9260,9 +9375,10 @@
       }
     },
     "node_modules/conventional-changelog-core/node_modules/semver": {
-      "version": "5.7.1",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
@@ -9362,9 +9478,10 @@
       }
     },
     "node_modules/conventional-changelog-writer/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -9522,24 +9639,16 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.24.1",
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.35.0.tgz",
+      "integrity": "sha512-5blwFAddknKeNgsjBzilkdQ0+YK8L1PfqPYq40NOYMYFSS38qj+hpTcLLWwpIwA2A5bje/x5jmVn2tzUMg9IVw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.21.3",
-        "semver": "7.0.0"
+        "browserslist": "^4.22.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
-      }
-    },
-    "node_modules/core-js-compat/node_modules/semver": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/core-js-pure": {
@@ -10046,9 +10155,10 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.211",
-      "dev": true,
-      "license": "ISC"
+      "version": "1.4.630",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.630.tgz",
+      "integrity": "sha512-osHqhtjojpCsACVnuD11xO5g9xaCyw7Qqn/C2KParkMv42i8jrJJgx3g7mkHfpxwhy9MnOJr8+pKOdZ7qzgizg==",
+      "dev": true
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -10507,9 +10617,10 @@
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -10580,9 +10691,10 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -11273,14 +11385,15 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.1",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -11580,9 +11693,10 @@
       }
     },
     "node_modules/git-semver-tags/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -12495,9 +12609,10 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -13236,7 +13351,8 @@
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -13621,9 +13737,10 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -13965,9 +14082,10 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.6",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
+      "dev": true
     },
     "node_modules/noms": {
       "version": "0.0.0",
@@ -14599,8 +14717,9 @@
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -15216,9 +15335,10 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "6.11.3",
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
+      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
       "hasInstallScript": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -15495,9 +15615,10 @@
       }
     },
     "node_modules/read-pkg/node_modules/semver": {
-      "version": "5.7.1",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
@@ -15896,7 +16017,8 @@
     },
     "node_modules/sax": {
       "version": "1.2.1",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
     },
     "node_modules/search-params": {
       "version": "3.0.0",
@@ -15908,8 +16030,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
-      "version": "7.5.0",
-      "license": "ISC",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -17031,7 +17154,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.5",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
       "dev": true,
       "funding": [
         {
@@ -17041,15 +17166,18 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"
       },
       "bin": {
-        "browserslist-lint": "cli.js"
+        "update-browserslist-db": "cli.js"
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
@@ -17208,9 +17336,10 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17272,16 +17401,21 @@
       }
     },
     "node_modules/xml2js": {
-      "version": "0.4.19",
-      "license": "MIT",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "dependencies": {
         "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/xmlbuilder": {
-      "version": "9.0.7",
-      "license": "MIT",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
       "engines": {
         "node": ">=4.0"
       }

--- a/src/DAL/pg/pgClient.ts
+++ b/src/DAL/pg/pgClient.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'fs';
+import { readFileSync } from 'node:fs';
 import { Pool, PoolClient, PoolConfig } from 'pg';
 import { container, injectable } from 'tsyringe';
 import { SERVICES } from '../../common/constants';

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -152,3 +152,8 @@ export interface ICacheProvider {
 export interface IPGClient {
   getPoolConnection: () => Promise<PoolClient>;
 }
+
+export enum SchemaType {
+  JSON = 'application/json',
+  YAML = 'application/yaml',
+}

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -153,6 +153,7 @@ export interface IPGClient {
   getPoolConnection: () => Promise<PoolClient>;
 }
 
+// TODO: use MIME Types
 export enum SchemaType {
   JSON = 'application/json',
   YAML = 'application/yaml',

--- a/src/common/providers/dbProvider.ts
+++ b/src/common/providers/dbProvider.ts
@@ -72,7 +72,7 @@ export class DBProvider implements IConfigProvider {
       return jsonContent;
     } catch (error) {
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      throw new Error(`Failed to provied json from database: ${error}`);
+      throw new Error(`Failed to provide json from database: ${error}`);
     } finally {
       client.release();
     }

--- a/src/common/providers/dbProvider.ts
+++ b/src/common/providers/dbProvider.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'fs';
+import { readFileSync } from 'node:fs';
 import { Logger } from '@map-colonies/js-logger';
 import { Pool, PoolClient, PoolConfig } from 'pg';
 import { container } from 'tsyringe';

--- a/src/common/providers/fSProvider.ts
+++ b/src/common/providers/fSProvider.ts
@@ -31,7 +31,7 @@ export class FSProvider implements IConfigProvider {
       const jsonContent = convertYamlToJson(yamlContent) as unknown as IMapProxyJsonDocument;
       return jsonContent;
     } catch (error) {
-      this.logger.error(`Failed to provied json from file: ${(error as Error).message}`);
+      this.logger.error(`Failed to provide json from file: ${(error as Error).message}`);
       throw error;
     }
   }

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,5 +1,5 @@
-import { extname, sep, join } from 'path';
-import { promises as fsp } from 'fs';
+import { extname, sep, join } from 'node:path';
+import { promises as fsp } from 'node:fs';
 import { safeLoad, safeDump, YAMLException } from 'js-yaml';
 import { container } from 'tsyringe';
 import { SERVICES } from '../common/constants';

--- a/src/configs/controllers/configsController.ts
+++ b/src/configs/controllers/configsController.ts
@@ -1,0 +1,33 @@
+import { Logger } from '@map-colonies/js-logger';
+import { RequestHandler } from 'express';
+import httpStatus from 'http-status-codes';
+import { injectable, inject } from 'tsyringe';
+import { SERVICES } from '../../common/constants';
+import { IMapProxyJsonDocument, SchemaType } from '../../common/interfaces';
+import { ConfigsManager } from '../models/configsManager';
+import { convertJsonToYaml } from '../../common/utils';
+
+type GetConfigHandler = RequestHandler<undefined, IMapProxyJsonDocument | string, undefined>;
+@injectable()
+export class ConfigsController {
+  public constructor(@inject(SERVICES.LOGGER) private readonly logger: Logger, @inject(ConfigsManager) private readonly manager: ConfigsManager) {}
+
+  public getConfig: GetConfigHandler = async (req, res, next) => {
+    try {
+      const configJson = await this.manager.getConfig();
+      let responseType = req.headers.accept;
+      let response;
+      if (responseType === SchemaType.YAML) {
+        response = convertJsonToYaml(configJson);
+      } else {
+        response = configJson;
+        responseType = SchemaType.JSON;
+      }
+
+      res.setHeader('Content-Type', responseType);
+      return res.status(httpStatus.OK).send(response);
+    } catch (error) {
+      next(error);
+    }
+  };
+}

--- a/src/configs/models/configsManager.ts
+++ b/src/configs/models/configsManager.ts
@@ -1,0 +1,21 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { inject, injectable } from 'tsyringe';
+import { Logger } from '@map-colonies/js-logger';
+import { SERVICES } from '../../common/constants';
+import { IMapProxyJsonDocument, IMapProxyConfig, IConfigProvider } from '../../common/interfaces';
+
+@injectable()
+class ConfigsManager {
+  public constructor(
+    @inject(SERVICES.LOGGER) private readonly logger: Logger,
+    @inject(SERVICES.MAPPROXY) private readonly mapproxyConfig: IMapProxyConfig,
+    @inject(SERVICES.CONFIGPROVIDER) private readonly configProvider: IConfigProvider
+  ) {}
+
+  public async getConfig(): Promise<IMapProxyJsonDocument> {
+    const jsonDocument: IMapProxyJsonDocument = await this.configProvider.getJson();
+    return jsonDocument;
+  }
+}
+
+export { ConfigsManager };

--- a/src/configs/routes/configsRouterFactory.ts
+++ b/src/configs/routes/configsRouterFactory.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import { FactoryFunction } from 'tsyringe';
+import { ConfigsController } from '../controllers/configsController';
+
+const configsRouterFactory: FactoryFunction<Router> = (dependencyContainer) => {
+  const router = Router();
+  const controller = dependencyContainer.resolve(ConfigsController);
+  router.get('/', controller.getConfig);
+
+  return router;
+};
+export const CONFIGS_ROUTER_SYMBOL = Symbol('configsRouterFactory');
+export { configsRouterFactory };

--- a/src/containerConfig.ts
+++ b/src/containerConfig.ts
@@ -7,6 +7,7 @@ import { SERVICES, SERVICE_NAME } from './common/constants';
 import { tracing } from './common/tracing';
 import { InjectionObject, registerDependencies } from './common/dependencyRegistration';
 import { layersRouterFactory, LAYERS_ROUTER_SYMBOL } from './layers/routes/layersRouterFactory';
+import { configsRouterFactory, CONFIGS_ROUTER_SYMBOL } from './configs/routes/configsRouterFactory';
 import { IConfigProvider, IFSConfig, IMapProxyConfig, IS3Config } from './common/interfaces';
 import { getProvider } from './getProvider';
 
@@ -30,6 +31,7 @@ export const registerExternalValues = (options?: RegisterOptions): DependencyCon
     { token: SERVICES.LOGGER, provider: { useValue: logger } },
     { token: SERVICES.TRACER, provider: { useValue: tracer } },
     { token: LAYERS_ROUTER_SYMBOL, provider: { useFactory: layersRouterFactory } },
+    { token: CONFIGS_ROUTER_SYMBOL, provider: { useFactory: configsRouterFactory } },
     { token: SERVICES.MAPPROXY, provider: { useValue: mapproxyConfig } },
     { token: SERVICES.FS, provider: { useValue: fsConfig } },
     { token: SERVICES.S3, provider: { useValue: s3Config } },

--- a/src/layers/models/layersManager.ts
+++ b/src/layers/models/layersManager.ts
@@ -31,16 +31,6 @@ class LayersManager {
     @inject(SERVICES.CONFIGPROVIDER) private readonly configProvider: IConfigProvider
   ) {}
 
-  public async getConfig(layerName: string): Promise<IMapProxyCache> {
-    const jsonDocument: IMapProxyJsonDocument = await this.configProvider.getJson();
-
-    if (!isLayerNameExists(jsonDocument, layerName)) {
-      throw new NotFoundError(`Layer name '${layerName}' is not exists`);
-    }
-    const requestedLayer: IMapProxyCache = jsonDocument.caches[layerName] as IMapProxyCache;
-    return requestedLayer;
-  }
-
   public async getLayer(layerName: string): Promise<IMapProxyCache> {
     const jsonDocument: IMapProxyJsonDocument = await this.configProvider.getJson();
 

--- a/src/layers/models/layersManager.ts
+++ b/src/layers/models/layersManager.ts
@@ -31,6 +31,16 @@ class LayersManager {
     @inject(SERVICES.CONFIGPROVIDER) private readonly configProvider: IConfigProvider
   ) {}
 
+  public async getConfig(layerName: string): Promise<IMapProxyCache> {
+    const jsonDocument: IMapProxyJsonDocument = await this.configProvider.getJson();
+
+    if (!isLayerNameExists(jsonDocument, layerName)) {
+      throw new NotFoundError(`Layer name '${layerName}' is not exists`);
+    }
+    const requestedLayer: IMapProxyCache = jsonDocument.caches[layerName] as IMapProxyCache;
+    return requestedLayer;
+  }
+
   public async getLayer(layerName: string): Promise<IMapProxyCache> {
     const jsonDocument: IMapProxyJsonDocument = await this.configProvider.getJson();
 

--- a/src/serverBuilder.ts
+++ b/src/serverBuilder.ts
@@ -10,6 +10,7 @@ import httpLogger from '@map-colonies/express-access-log-middleware';
 import { SERVICES } from './common/constants';
 import { IConfig } from './common/interfaces';
 import { LAYERS_ROUTER_SYMBOL } from './layers/routes/layersRouterFactory';
+import { CONFIGS_ROUTER_SYMBOL } from './configs/routes/configsRouterFactory';
 
 @injectable()
 export class ServerBuilder {
@@ -18,7 +19,8 @@ export class ServerBuilder {
   public constructor(
     @inject(SERVICES.CONFIG) private readonly config: IConfig,
     @inject(SERVICES.LOGGER) private readonly logger: Logger,
-    @inject(LAYERS_ROUTER_SYMBOL) private readonly layersRouter: Router
+    @inject(LAYERS_ROUTER_SYMBOL) private readonly layersRouter: Router,
+    @inject(CONFIGS_ROUTER_SYMBOL) private readonly configsRouter: Router
   ) {
     this.serverInstance = express();
   }
@@ -41,6 +43,7 @@ export class ServerBuilder {
   }
 
   private buildRoutes(): void {
+    this.serverInstance.use('/config', this.configsRouter);
     this.serverInstance.use('/', this.layersRouter);
     this.buildDocsRoutes();
   }

--- a/tests/configurations/initJestOpenapi.setup.ts
+++ b/tests/configurations/initJestOpenapi.setup.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import jestOpenApi from 'jest-openapi';
 
 jestOpenApi(path.join(process.cwd(), 'openapi3.yaml'));

--- a/tests/configurations/integration/jest.config.js
+++ b/tests/configurations/integration/jest.config.js
@@ -2,19 +2,22 @@ module.exports = {
   transform: {
     '^.+\\.ts$': 'ts-jest',
   },
-  globals: {
-    'ts-jest': {
-      tsconfig: 'tsconfig.test.json',
-    },
+  transform: {
+    '^.+\\.ts$': ['ts-jest', { tsconfig: 'tsconfig.test.json' }],
   },
+  setupFiles: ['<rootDir>/tests/configurations/jest.setup.ts'],
   coverageReporters: ['text', 'html'],
   collectCoverage: true,
-  collectCoverageFrom: ['<rootDir>/src/**/*.ts', '!*/node_modules/', '!/vendor/**', '!*/common/**', '!**/models/**', '!<rootDir>/src/*'],
+  collectCoverageFrom: [
+    '<rootDir>/src/**/*.ts',
+    '!*/node_modules/',
+    '!/vendor/**',
+    '!*/common/**',
+    '!**/models/**',
+    '!<rootDir>/src/*',
+    '!<rootDir>/src/DAL/**',
+  ],
   coverageDirectory: '<rootDir>/coverage',
-  rootDir: '../../../.',
-  testMatch: ['<rootDir>/tests/integration/**/*.spec.ts'],
-  setupFiles: ['<rootDir>/tests/configurations/jest.setup.ts'],
-  setupFilesAfterEnv: ['jest-openapi', '<rootDir>/tests/configurations/initJestOpenapi.setup.ts'],
   reporters: [
     'default',
     [
@@ -22,17 +25,18 @@ module.exports = {
       { multipleReportsUnitePath: './reports', pageTitle: 'integration', publicPath: './reports', filename: 'integration.html' },
     ],
   ],
-  collectCoverage: true,
-  moduleDirectories: ['node_modules', 'src'],
-  collectCoverageFrom: ['<rootDir>/src/**/*.{ts}', '!**/node_modules/**', '!**/vendor/**', '!<rootDir>/src/DAL/**'],
+  rootDir: '../../../.',
+  setupFilesAfterEnv: ['jest-openapi', '<rootDir>/tests/configurations/initJestOpenapi.setup.ts'],
   preset: 'ts-jest',
+  testMatch: ['<rootDir>/tests/integration/**/*.spec.ts'],
   testEnvironment: 'node',
+  moduleDirectories: ['node_modules', 'src'],
   coverageThreshold: {
     global: {
-      branches: 80,
-      functions: 80,
-      lines: 80,
-      statements: -10,
+      branches: 100,
+      functions: 100,
+      lines: 98,
+      statements: 98,
     },
   },
 };

--- a/tests/configurations/integration/jest.config.js
+++ b/tests/configurations/integration/jest.config.js
@@ -35,8 +35,8 @@ module.exports = {
     global: {
       branches: 100,
       functions: 100,
-      lines: 98,
-      statements: 98,
+      lines: 100,
+      statements: 100,
     },
   },
 };

--- a/tests/configurations/unit/jest.config.js
+++ b/tests/configurations/unit/jest.config.js
@@ -2,11 +2,6 @@ module.exports = {
   transform: {
     '^.+\\.ts$': 'ts-jest',
   },
-  globals: {
-    'ts-jest': {
-      tsconfig: 'tsconfig.test.json',
-    },
-  },
   testMatch: ['<rootDir>/tests/unit/**/*.spec.ts'],
   coverageReporters: ['text', 'html'],
   collectCoverage: true,
@@ -31,10 +26,10 @@ module.exports = {
   testEnvironment: 'node',
   coverageThreshold: {
     global: {
-      branches: 80,
+      branches: 75,
       functions: 80,
       lines: 80,
-      statements: -10,
+      statements: 10,
     },
   },
 };

--- a/tests/integration/configs/configsManager.spec.ts
+++ b/tests/integration/configs/configsManager.spec.ts
@@ -1,0 +1,87 @@
+import httpStatusCodes from 'http-status-codes';
+import jsLogger from '@map-colonies/js-logger';
+import { trace } from '@opentelemetry/api';
+import config from 'config';
+import { container } from 'tsyringe';
+import { NotFoundError } from '@map-colonies/error-types';
+import { IFSConfig, IMapProxyConfig, IMapProxyJsonDocument, IS3Config } from '../../../src/common/interfaces';
+import { MockConfigProvider, init as configProviderInit, getJsonMock } from '../../unit/mock/mockConfigProvider';
+import * as utils from '../../../src/common/utils';
+import { getApp } from '../../../src/app';
+import { SERVICES } from '../../../src/common/constants';
+import { configsRouterFactory, CONFIGS_ROUTER_SYMBOL } from '../../../src/configs/routes/configsRouterFactory';
+import { ConfigsRequestSender } from '../configs/helpers/requestSender';
+import { mockData } from '../../unit/mock/mockData';
+
+let requestSender: ConfigsRequestSender;
+describe('configManager', () => {
+  beforeEach(() => {
+    const mapproxyConfig = config.get<IMapProxyConfig>('mapproxy');
+    const fsConfig = config.get<IFSConfig>('FS');
+    const s3Config = config.get<IS3Config>('S3');
+    configProviderInit();
+    /* eslint-disable-next-line @typescript-eslint/naming-convention*/
+    const app = getApp({
+      override: [
+        { token: SERVICES.MAPPROXY, provider: { useValue: mapproxyConfig } },
+        { token: SERVICES.LOGGER, provider: { useValue: jsLogger({ enabled: false }) } },
+        { token: SERVICES.TRACER, provider: { useValue: trace.getTracer('testTracer') } },
+        { token: SERVICES.CONFIG, provider: { useValue: config } },
+        { token: CONFIGS_ROUTER_SYMBOL, provider: { useFactory: configsRouterFactory } },
+        { token: SERVICES.FS, provider: { useValue: fsConfig } },
+        { token: SERVICES.S3, provider: { useValue: s3Config } },
+        {
+          token: SERVICES.CONFIGPROVIDER,
+          provider: {
+            useValue: MockConfigProvider,
+          },
+        },
+      ],
+      useChild: false,
+    });
+    requestSender = new ConfigsRequestSender(app);
+    // jest.spyOn(utils, 'replaceYamlFileContent').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    jest.clearAllMocks();
+    container.reset();
+    container.clearInstances();
+  });
+
+  describe('#getConfig', () => {
+    it('Happy Path - should return status 200 and current config as json default', async () => {
+      const mockMapproxyConfig = mockData();
+      getJsonMock.mockResolvedValue(mockMapproxyConfig);
+      const response = await requestSender.getConfig();
+
+      expect(response.status).toBe(httpStatusCodes.OK);
+      const resource = response.body as IMapProxyJsonDocument;
+      expect(response).toSatisfyApiSpec();
+      expect(resource).toEqual(mockMapproxyConfig);
+    });
+
+    it('Happy Path - should return status 200 and current config as yaml', async () => {
+      const mockMapproxyConfig = mockData();
+      getJsonMock.mockResolvedValue(mockMapproxyConfig);
+      const response = await requestSender.getConfigYaml();
+      expect(response.status).toBe(httpStatusCodes.OK);
+      const resource = response.text;
+      expect(response).toSatisfyApiSpec();
+      expect(resource).toEqual(utils.convertJsonToYaml(mockMapproxyConfig));
+    });
+
+    it('Sad Path - should fail with response status 404 Not Found and config not exists', async () => {
+      getJsonMock.mockImplementation(() => {
+        throw new NotFoundError('some connect problem');
+      });
+      const response = await requestSender.getConfig();
+
+      expect(response).toSatisfyApiSpec();
+      expect(response.status).toBe(httpStatusCodes.NOT_FOUND);
+      expect(response.body).toEqual({ message: 'some connect problem' });
+    });
+  });
+});

--- a/tests/integration/configs/helpers/requestSender.ts
+++ b/tests/integration/configs/helpers/requestSender.ts
@@ -1,0 +1,13 @@
+import * as supertest from 'supertest';
+
+export class ConfigsRequestSender {
+  public constructor(private readonly app: Express.Application) {}
+
+  public async getConfig(): Promise<supertest.Response> {
+    return supertest.agent(this.app).get(`/config`).set('accept', 'application/json');
+  }
+
+  public async getConfigYaml(): Promise<supertest.Response> {
+    return supertest.agent(this.app).get(`/config`).set('accept', 'application/yaml');
+  }
+}

--- a/tests/integration/layers/layersManager.spec.ts
+++ b/tests/integration/layers/layersManager.spec.ts
@@ -4,6 +4,7 @@ import { trace } from '@opentelemetry/api';
 import config from 'config';
 import { container } from 'tsyringe';
 import { TileOutputFormat } from '@map-colonies/mc-model-types';
+import { NotFoundError } from '@map-colonies/error-types';
 import {
   IFSConfig,
   ILayerPostRequest,
@@ -15,7 +16,7 @@ import {
 } from '../../../src/common/interfaces';
 import { mockLayerNameIsNotExists } from '../../unit/mock/mockLayerNameIsNotExists';
 import { mockLayerNameAlreadyExists } from '../../unit/mock/mockLayerNameAlreadyExists';
-import { MockConfigProvider, init as configProviderInit } from '../../unit/mock/mockConfigProvider';
+import { MockConfigProvider, init as configProviderInit, updateJsonMock } from '../../unit/mock/mockConfigProvider';
 import * as utils from '../../../src/common/utils';
 import { getApp } from '../../../src/app';
 import { SERVICES } from '../../../src/common/constants';
@@ -161,6 +162,17 @@ describe('layerManager', () => {
 
       expect(response).toSatisfyApiSpec();
       expect(response.status).toBe(httpStatusCodes.OK);
+    });
+
+    it('sad Path - should return status 404', async () => {
+      const mockLayerNames = ['mockLayerNameExists', 'NameIsAlreadyExists'];
+      updateJsonMock.mockImplementation(() => {
+        throw new NotFoundError('some problem');
+      });
+      const response = await requestSender.removeLayer(mockLayerNames);
+
+      expect(response).toSatisfyApiSpec();
+      expect(response.status).toBe(httpStatusCodes.NOT_FOUND);
     });
   });
 

--- a/tests/unit/configs/common/utils.spec.ts
+++ b/tests/unit/configs/common/utils.spec.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'fs';
+import { readFileSync } from 'node:fs';
 import jsyaml, { YAMLException } from 'js-yaml';
 import * as utils from '../../../../src/common/utils';
 import { IMapProxyJsonDocument, IMapProxyLayer, IMosaicLayerObject } from '../../../../src/common/interfaces';

--- a/tests/unit/configs/common/utils.spec.ts
+++ b/tests/unit/configs/common/utils.spec.ts
@@ -1,0 +1,132 @@
+import { readFileSync } from 'fs';
+import jsyaml, { YAMLException } from 'js-yaml';
+import * as utils from '../../../../src/common/utils';
+import { IMapProxyJsonDocument, IMapProxyLayer, IMosaicLayerObject } from '../../../../src/common/interfaces';
+
+let safeLoadStub: jest.SpyInstance;
+let safeDumpStub: jest.SpyInstance;
+let sortArrayByZIndexStub: jest.SpyInstance;
+let replaceYamlFileContentStub: jest.SpyInstance;
+
+describe('utils', () => {
+  beforeEach(function () {
+    // stub util functions
+    safeLoadStub = jest.spyOn(jsyaml, 'safeLoad');
+    safeDumpStub = jest.spyOn(jsyaml, 'safeDump');
+    sortArrayByZIndexStub = jest.spyOn(utils, 'sortArrayByZIndex');
+    replaceYamlFileContentStub = jest.spyOn(utils, 'replaceYamlFileContent');
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  describe('#convertYamlToJson', () => {
+    it('should convert yaml content to json object', function () {
+      // mock
+      const mockYamlFile = 'tests/unit/mock/mockContent.yaml';
+      const yamlContent = readFileSync(mockYamlFile, { encoding: 'utf8' });
+      // action
+      const action = () => utils.convertYamlToJson(yamlContent);
+      // expectation
+      expect(typeof action()).toBe('object');
+      expect(safeLoadStub).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reject with invalid yaml syntax', function () {
+      // mock
+      const invalidYamlSyntaxFile = 'tests/unit/mock/mockInvalidYamlSyntax.yaml';
+      const yamlContent = readFileSync(invalidYamlSyntaxFile, { encoding: 'utf8' });
+      // action
+      const action = () => utils.convertYamlToJson(yamlContent);
+      // expectation
+      expect(action).toThrow(YAMLException);
+      expect(safeLoadStub).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('#convertJsonToYaml', () => {
+    it('should convert json object content to yaml content', function () {
+      // mock
+      const mockYamlFile = 'tests/unit/mock/mockContent.yaml';
+      const yamlContent = readFileSync(mockYamlFile, { encoding: 'utf8' });
+      const mockConvertedJson: IMapProxyJsonDocument = utils.convertYamlToJson(yamlContent);
+      // action
+      const convertedYaml: string = utils.convertJsonToYaml(mockConvertedJson);
+      // expectation
+      expect(typeof convertedYaml).toBe('string');
+      expect(safeDumpStub).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('#replaceYamlFileContent', () => {
+    it('should replace file content with the requested yaml content', function () {
+      // mock
+      const mockYamlFile = 'tests/unit/mock/mockContent.yaml';
+      const yamlContent = readFileSync(mockYamlFile, { encoding: 'utf8' });
+      const mockConvertedJson: IMapProxyJsonDocument = utils.convertYamlToJson(yamlContent);
+      const mockLayer: IMapProxyLayer = {
+        name: 'mockLayer',
+        sources: ['mockSource'],
+      };
+
+      expect(mockConvertedJson.layers).not.toContainEqual(mockLayer);
+      mockConvertedJson.layers.push(mockLayer);
+
+      // action
+      const convertedYaml: string = utils.convertJsonToYaml(mockConvertedJson);
+      const newConvertedJson: IMapProxyJsonDocument = jsyaml.safeLoad(convertedYaml) as IMapProxyJsonDocument;
+      replaceYamlFileContentStub.mockResolvedValue(undefined);
+      const action = async () => utils.replaceYamlFileContent(mockYamlFile, convertedYaml);
+
+      // expectation
+      expect(action).not.toThrow();
+      expect(typeof convertedYaml).toBe('string');
+      expect(newConvertedJson.layers).toContainEqual(mockLayer);
+    });
+  });
+
+  describe('#sortArrayByZIndex', () => {
+    it('should sort an array in numerical order', function () {
+      // mock
+      const layers: IMosaicLayerObject[] = [
+        { layerName: 'mockLayer1', zIndex: 2 },
+        { layerName: 'mockLayer2', zIndex: 1 },
+        { layerName: 'mockLayer3', zIndex: 0 },
+      ];
+      // action
+      const action = () => utils.sortArrayByZIndex(layers);
+
+      // expectation
+      expect(layers[0].layerName).toBe('mockLayer1');
+      expect(layers[1].layerName).toBe('mockLayer2');
+      expect(layers[2].layerName).toBe('mockLayer3');
+      expect(action()).toEqual(['mockLayer3', 'mockLayer2', 'mockLayer1']);
+      expect(sortArrayByZIndexStub).toHaveReturned();
+      expect(sortArrayByZIndexStub).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('#getFileExtension', () => {
+    it('should return the file extension from a path', function () {
+      // mock
+      const path = '/path/to/file.gpkg';
+      // action
+      const action = () => utils.getFileExtension(path);
+
+      // expectation
+      expect(action()).toBe('.gpkg');
+    });
+
+    it('should return the empty string if the path does not contain file extension', function () {
+      // mock
+      const path = '/path/to/dir/';
+      // action
+      const action = () => utils.getFileExtension(path);
+
+      // expectation
+      expect(action()).toBe('');
+    });
+  });
+});

--- a/tests/unit/configs/models/configsManager.spec.ts
+++ b/tests/unit/configs/models/configsManager.spec.ts
@@ -1,0 +1,54 @@
+import { container } from 'tsyringe';
+import jsLogger from '@map-colonies/js-logger';
+import { NotFoundError } from '@map-colonies/error-types';
+import { IMapProxyConfig, IMapProxyJsonDocument } from '../../../../src/common/interfaces';
+import { ConfigsManager } from '../../../../src/configs/models/configsManager';
+import { MockConfigProvider, getJsonMock, init as initConfigProvider } from '../../mock/mockConfigProvider';
+import { SERVICES } from '../../../../src/common/constants';
+import { registerTestValues } from '../../../integration/testContainerConfig';
+import { mockData } from '../../mock/mockData';
+
+let configManager: ConfigsManager;
+const logger = jsLogger({ enabled: false });
+
+describe('layersManager', () => {
+  beforeEach(() => {
+    // stub util functions
+    registerTestValues();
+    initConfigProvider();
+    const mapproxyConfig = container.resolve<IMapProxyConfig>(SERVICES.MAPPROXY);
+    configManager = new ConfigsManager(logger, mapproxyConfig, MockConfigProvider);
+  });
+
+  afterEach(() => {
+    container.reset();
+    container.clearInstances();
+    jest.clearAllMocks();
+  });
+
+  describe('#getConfig', () => {
+    it('should successfully return the current config', async () => {
+      const resultData = mockData();
+      getJsonMock.mockResolvedValue(resultData);
+
+      // action
+      const resource: IMapProxyJsonDocument = await configManager.getConfig();
+      // expectation;
+      expect(getJsonMock).toHaveBeenCalledTimes(1);
+      expect(resource).toBe(resultData);
+    });
+
+    it('should reject with error', async () => {
+      // action
+      getJsonMock.mockImplementation(() => {
+        throw new NotFoundError('some connect problem');
+      });
+      const action = async () => {
+        await configManager.getConfig();
+      };
+      // expectation;
+      await expect(action).rejects.toThrow(new NotFoundError('some connect problem'));
+      expect(getJsonMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/tests/unit/layers/models/layersManager.spec.ts
+++ b/tests/unit/layers/models/layersManager.spec.ts
@@ -1,4 +1,4 @@
-import { normalize } from 'path';
+import { normalize } from 'node:path';
 import { container } from 'tsyringe';
 import jsLogger from '@map-colonies/js-logger';
 import { ConflictError, NotFoundError } from '@map-colonies/error-types';
@@ -288,6 +288,15 @@ describe('layersManager', () => {
       const cacheProvider = layersManager.getCacheType(cacheType, mockTilesPath);
       // expectation
       expect(cacheProvider).toEqual(expectedResult);
+    });
+
+    it('should throw exception on illegal value', () => {
+      const cacheType = 'badProvider';
+      // action
+      const action = () => layersManager.getCacheType(cacheType, mockTilesPath);
+      // expectation
+      const msg = `Invalid cache source: ${cacheType} has been provided , available values: "geopackage", "s3", "file"`;
+      expect(action).toThrow(Error(msg));
     });
   });
 });

--- a/tests/unit/mock/mockConfigProvider.ts
+++ b/tests/unit/mock/mockConfigProvider.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'fs';
+import { readFileSync } from 'node:fs';
 import { IConfigProvider, IMapProxyJsonDocument } from '../../../src/common/interfaces';
 
 const updateJsonMock = jest.fn();


### PR DESCRIPTION
GetConfig - New API


| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✔                                                                       |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✖                                                                       |

The getConfig API is GET request sended and return the current configuration that mapproxy running.

it compatible return as yaml or as json depends on the user request header (content-type)

as default will return json format.

mapproxy actual using is by yaml format.
