### PR TITLE
feat:  adding mimeType image format manipulate (MAPCO-3257)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@map-colonies/error-types": "^1.1.3",
         "@map-colonies/express-access-log-middleware": "^2.0.1",
         "@map-colonies/js-logger": "^1.0.1",
-        "@map-colonies/mc-model-types": "^14.1.2",
+        "@map-colonies/mc-model-types": "^15.2.0",
         "@map-colonies/openapi-express-viewer": "^3.0.0",
         "@map-colonies/read-pkg": "0.0.1",
         "@map-colonies/telemetry": "4.1.0",
@@ -3085,15 +3085,16 @@
       }
     },
     "node_modules/@map-colonies/mc-model-types": {
-      "version": "14.1.2",
-      "resolved": "https://registry.npmjs.org/@map-colonies/mc-model-types/-/mc-model-types-14.1.2.tgz",
-      "integrity": "sha512-ntG/25MJ9x+DkmtPzxmwfC6PCbuNrVOiAekTkVVl0ik9uWWkrY4/mE0t4wPb03LXCpEpGgSK58Tx8Oa/fFWlVQ==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@map-colonies/mc-model-types/-/mc-model-types-15.2.0.tgz",
+      "integrity": "sha512-adjm86SAsTtFYF+A2skNQUkVITc7s3VlGSX5/vFcoVZAYJagLHyD2PVi1CSf3TrtLXfXGu1RD5Y3xmagpsorfg==",
       "dependencies": {
         "@types/geojson": "^7946.0.7",
         "reflect-metadata": "^0.1.13"
       },
       "peerDependencies": {
-        "@map-colonies/mc-utils": ">=1.8.0"
+        "@map-colonies/mc-utils": ">=1.8.0",
+        "@map-colonies/types": ">=1.3.0"
       }
     },
     "node_modules/@map-colonies/mc-utils": {
@@ -3265,9 +3266,20 @@
         "node": ">=8.12.0"
       }
     },
+    "node_modules/@map-colonies/types": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@map-colonies/types/-/types-1.3.3.tgz",
+      "integrity": "sha512-cFohxC6jgMjF77a5wc0IpEgPP6Y2wYIuC/y+Dop2PNUNA98Mq1fuTX85S0R+XLt8DUr/8r0bWhXp9ZNpEhj7ow==",
+      "peer": true,
+      "dependencies": {
+        "@types/mime-types": "^2.1.1",
+        "copyfiles": "^2.4.1",
+        "epsg-index": "^1.3.0",
+        "ts-morph": "^18.0.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -3279,7 +3291,6 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -3287,7 +3298,6 @@
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -5404,6 +5414,57 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@ts-morph/common": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.19.0.tgz",
+      "integrity": "sha512-Unz/WHmd4pGax91rdIKWi51wnVUW11QttMEPpBiBgIewnc9UQIX7UDLxr5vRlqeByXCwhkF6VabSsI0raWcyAQ==",
+      "peer": true,
+      "dependencies": {
+        "fast-glob": "^3.2.12",
+        "minimatch": "^7.4.3",
+        "mkdirp": "^2.1.6",
+        "path-browserify": "^1.0.1"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/minimatch": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
+      "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/mkdirp": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
+      "integrity": "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==",
+      "peer": true,
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "dev": true,
@@ -7418,6 +7479,12 @@
       "version": "1.43.1",
       "license": "MIT"
     },
+    "node_modules/@types/mime-types": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
+      "integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
+      "peer": true
+    },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "dev": true,
@@ -8598,7 +8665,6 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -8607,7 +8673,6 @@
     },
     "node_modules/braces": {
       "version": "3.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.0.1"
@@ -8914,6 +8979,12 @@
         "node": ">= 0.12.0"
       }
     },
+    "node_modules/code-block-writer": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-12.0.0.tgz",
+      "integrity": "sha512-q4dMFMlXtKR3XNBHyMHt/3pwYNA69EDk00lloMOaaUMKPUXBw6lpXtbu3MMVG6/uOihGnRDOlkyqsONEUj60+w==",
+      "peer": true
+    },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.1",
       "dev": true,
@@ -9064,7 +9135,6 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-stream": {
@@ -9605,7 +9675,6 @@
     },
     "node_modules/copyfiles": {
       "version": "2.4.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "glob": "^7.0.5",
@@ -9623,7 +9692,6 @@
     },
     "node_modules/copyfiles/node_modules/through2": {
       "version": "2.0.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readable-stream": "~2.3.6",
@@ -9632,7 +9700,6 @@
     },
     "node_modules/copyfiles/node_modules/yargs": {
       "version": "16.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^7.0.2",
@@ -10204,6 +10271,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/epsg-index": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/epsg-index/-/epsg-index-1.3.0.tgz",
+      "integrity": "sha512-pWJ7lkMbH0Au+MJyBV4GxiX+KmOknPc6c5FqDAYD61Ju3LblR60VGmOlteBhK9Dm3oy++Jxa2kUimONeSvsKRA==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/error-ex": {
@@ -11119,9 +11195,9 @@
       "license": "MIT"
     },
     "node_modules/fast-glob": {
-      "version": "3.2.11",
-      "dev": true,
-      "license": "MIT",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -11266,7 +11342,6 @@
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -11720,7 +11795,6 @@
     },
     "node_modules/glob": {
       "version": "7.2.3",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -11739,7 +11813,6 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -12331,7 +12404,6 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12367,7 +12439,6 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -12396,7 +12467,6 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -13857,7 +13927,6 @@
     },
     "node_modules/merge2": {
       "version": "1.4.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -13872,7 +13941,6 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.2",
@@ -13927,7 +13995,6 @@
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -13963,7 +14030,6 @@
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -14119,7 +14185,6 @@
     },
     "node_modules/noms": {
       "version": "0.0.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "inherits": "^2.0.1",
@@ -14128,12 +14193,10 @@
     },
     "node_modules/noms/node_modules/isarray": {
       "version": "0.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/noms/node_modules/readable-stream": {
       "version": "1.0.34",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -14144,7 +14207,6 @@
     },
     "node_modules/noms/node_modules/string_decoder": {
       "version": "0.10.31",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/normalize-package-data": {
@@ -14586,6 +14648,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "peer": true
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "dev": true,
@@ -14596,7 +14664,6 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -14753,7 +14820,6 @@
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -15995,7 +16061,6 @@
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -16803,7 +16868,6 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -16913,6 +16977,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ts-morph": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-18.0.0.tgz",
+      "integrity": "sha512-Kg5u0mk19PIIe4islUI/HWRvm9bC1lHejK4S0oh1zaZ77TMZAEmQC0sHQYiu2RgCQFZKXz1fMVi/7nOOeirznA==",
+      "peer": true,
+      "dependencies": {
+        "@ts-morph/common": "~0.19.0",
+        "code-block-writer": "^12.0.0"
       }
     },
     "node_modules/ts-node": {
@@ -17177,7 +17251,6 @@
     },
     "node_modules/untildify": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@map-colonies/error-types": "^1.1.3",
     "@map-colonies/express-access-log-middleware": "^2.0.1",
     "@map-colonies/js-logger": "^1.0.1",
-    "@map-colonies/mc-model-types": "^14.1.2",
+    "@map-colonies/mc-model-types": "^15.2.0",
     "@map-colonies/openapi-express-viewer": "^3.0.0",
     "@map-colonies/read-pkg": "0.0.1",
     "@map-colonies/telemetry": "4.1.0",

--- a/src/common/enums.ts
+++ b/src/common/enums.ts
@@ -10,8 +10,3 @@ export enum SourceTypes {
   FS = 'file',
   REDIS = 'redis',
 }
-
-export enum TileFormat {
-  JPEG = 'image/jpeg',
-  PNG = 'image/png',
-}

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -2,7 +2,8 @@
 import { PoolClient } from 'pg';
 import { JsonObject } from 'swagger-ui-express';
 import { TileOutputFormat } from '@map-colonies/mc-model-types';
-import { Providers, TileFormat } from './enums';
+import { TilesMimeFormat } from '@map-colonies/types';
+import { Providers } from './enums';
 
 export interface IConfig {
   get: <T>(setting: string) => T;
@@ -43,7 +44,7 @@ export interface IMapProxyConfig {
   configProvider: Providers;
   cache: {
     grids: string;
-    format: TileFormat;
+    format: TilesMimeFormat;
     upscaleTiles: number;
     directoryLayout: string;
     gpkgExt: string;

--- a/src/layers/models/layersManager.ts
+++ b/src/layers/models/layersManager.ts
@@ -2,7 +2,7 @@
 import { container, inject, injectable } from 'tsyringe';
 import { Logger } from '@map-colonies/js-logger';
 import { ConflictError, NotFoundError } from '@map-colonies/error-types';
-import { TileOutputFormat } from '@map-colonies/mc-model-types';
+import { lookup as mimeLookup, TilesMimeFormat } from '@map-colonies/types';
 import { SERVICES } from '../../common/constants';
 import {
   ILayerPostRequest,
@@ -22,7 +22,7 @@ import { isLayerNameExists } from '../../common/validations/isLayerNameExists';
 import { S3Source } from '../../common/cacheProviders/S3Source';
 import { GpkgSource } from '../../common/cacheProviders/gpkgSource';
 import { FSSource } from '../../common/cacheProviders/fsSource';
-import { SourceTypes, TileFormat } from '../../common/enums';
+import { SourceTypes } from '../../common/enums';
 import { RedisSource } from '../../common/cacheProviders/redisSource';
 
 @injectable()
@@ -33,7 +33,6 @@ class LayersManager {
     @inject(SERVICES.REDISCONFIG) private readonly redisConfig: IRedisConfig,
     @inject(SERVICES.CONFIGPROVIDER) private readonly configProvider: IConfigProvider
   ) {}
-
   public async getLayer(layerName: string): Promise<IMapProxyCache> {
     const jsonDocument: IMapProxyJsonDocument = await this.configProvider.getJson();
 
@@ -165,7 +164,7 @@ class LayersManager {
 
   public async updateLayer(layerName: string, layerRequest: ILayerPostRequest): Promise<void> {
     this.logger.info({ msg: `Update layer: '${layerName}' request`, layerRequest });
-    const tileFormat = this.mapToTileFormat(layerRequest.format);
+    const tileMimeFormat = mimeLookup(layerRequest.format) as TilesMimeFormat;
     const isRedisCache = !layerName.endsWith('-source');
     let doesHaveRedisCache = false;
 
@@ -186,7 +185,7 @@ class LayersManager {
 
       if (isRedisCache || doesHaveRedisCache) {
         // update existing layer cache values with the new requested layer cache values
-        const newRedisCache: IMapProxyCache = this.createRedisCache(redisLayerName, sourceLayerName, tileFormat, this.mapproxyConfig);
+        const newRedisCache: IMapProxyCache = this.createRedisCache(redisLayerName, sourceLayerName, tileMimeFormat, this.mapproxyConfig);
         jsonDocument.caches[redisLayerName] = newRedisCache;
         // update existing layer values with the new requested layer values
         newLayer = this.getLayerValues(redisLayerName);
@@ -197,7 +196,7 @@ class LayersManager {
         const sourceLayerNameIndex: number = jsonDocument.layers.findIndex((layer) => layer.name === sourceLayerName);
         jsonDocument.layers[sourceLayerNameIndex] = newLayer;
       }
-      const newSourceCache: IMapProxyCache = this.getCacheValues(layerRequest.cacheType, layerRequest.tilesPath, tileFormat);
+      const newSourceCache: IMapProxyCache = this.getCacheValues(layerRequest.cacheType, layerRequest.tilesPath, tileMimeFormat);
       jsonDocument.caches[sourceLayerName] = newSourceCache;
 
       return jsonDocument;
@@ -272,8 +271,8 @@ class LayersManager {
     if (isLayerNameExists(jsonDocument, sourceCacheTitle)) {
       throw new ConflictError(`Layer name '${sourceCacheTitle}' already exists`);
     }
-    const tileFormat = this.mapToTileFormat(layerRequest.format);
-    const newCache: IMapProxyCache = this.getCacheValues(layerRequest.cacheType, layerRequest.tilesPath, tileFormat);
+    const tileMimeFormat = mimeLookup(layerRequest.format) as TilesMimeFormat;
+    const newCache: IMapProxyCache = this.getCacheValues(layerRequest.cacheType, layerRequest.tilesPath, tileMimeFormat);
     this.logger.info(`adding ${sourceCacheTitle} to cache list`);
     jsonDocument.caches[sourceCacheTitle] = newCache;
     this.addNewLayer(sourceCacheTitle, jsonDocument);
@@ -293,12 +292,12 @@ class LayersManager {
     if (isLayerNameExists(jsonDocument, sourceCacheTitle)) {
       throw new ConflictError(`Layer name '${sourceCacheTitle}' already exists`);
     }
-    const tileFormat = this.mapToTileFormat(layerRequest.format);
+    const tileMimeFormat = mimeLookup(layerRequest.format) as TilesMimeFormat;
     this.logger.info(`adding ${sourceCacheTitle} to cache list`);
-    const sourceCacheBase: IMapProxyCache = this.getCacheValues(layerRequest.cacheType, layerRequest.tilesPath, tileFormat);
+    const sourceCacheBase: IMapProxyCache = this.getCacheValues(layerRequest.cacheType, layerRequest.tilesPath, tileMimeFormat);
     jsonDocument.caches[`${sourceCacheTitle}`] = sourceCacheBase;
     this.logger.info(`adding ${redisCacheTitle} to cache list`);
-    const redisCache: IMapProxyCache = this.createRedisCache(redisCacheTitle, sourceCacheTitle, tileFormat, this.mapproxyConfig);
+    const redisCache: IMapProxyCache = this.createRedisCache(redisCacheTitle, sourceCacheTitle, tileMimeFormat, this.mapproxyConfig);
     jsonDocument.caches[`${redisCacheTitle}`] = redisCache;
     this.addNewLayer(redisCacheTitle, jsonDocument);
   }
@@ -316,14 +315,6 @@ class LayersManager {
     };
 
     return cache;
-  }
-
-  private mapToTileFormat(tileOutputFormat: TileOutputFormat): TileFormat {
-    if (tileOutputFormat === TileOutputFormat.JPEG) {
-      return TileFormat.JPEG;
-    } else {
-      return TileFormat.PNG;
-    }
   }
 }
 

--- a/tests/unit/layers/models/layersManager.spec.ts
+++ b/tests/unit/layers/models/layersManager.spec.ts
@@ -4,6 +4,7 @@ import { container } from 'tsyringe';
 import jsLogger from '@map-colonies/js-logger';
 import { ConflictError, NotFoundError } from '@map-colonies/error-types';
 import { TileOutputFormat } from '@map-colonies/mc-model-types';
+import { lookup as mimeLookup, TilesMimeFormat } from '@map-colonies/types';
 import config from 'config';
 import {
   ILayerPostRequest,
@@ -21,7 +22,6 @@ import { MockConfigProvider, getJsonMock, updateJsonMock, init as initConfigProv
 import { SERVICES } from '../../../../src/common/constants';
 import { registerTestValues } from '../../../integration/testContainerConfig';
 import { init as initConfig, clear as clearConfig } from '../../../configurations/config';
-import { TileFormat } from '../../../../src/common/enums';
 
 let layersManager: LayersManager;
 let sortArrayByZIndexStub: jest.SpyInstance;
@@ -345,13 +345,15 @@ describe('layersManager', () => {
       // mock
       const mockLayerName = 'redisExists-source';
       const mockRedisLayerName = 'redisExists';
+      const expectedTileMimeFormatPng = mimeLookup(TileOutputFormat.PNG) as TilesMimeFormat;
+      const expectedTileMimeFormatJpeg = mimeLookup(TileOutputFormat.JPEG) as TilesMimeFormat;
 
       //check data
       const data = await MockConfigProvider.getJson();
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      expect(data.caches[mockLayerName].format).toBe(TileFormat.PNG);
+      expect(data.caches[mockLayerName].format).toBe(expectedTileMimeFormatPng);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      expect(data.caches[mockRedisLayerName].format).toBe(TileFormat.PNG);
+      expect(data.caches[mockRedisLayerName].format).toBe(expectedTileMimeFormatPng);
 
       // action
       const action = layersManager.updateLayer(mockLayerName, mockUpdateLayerRequest);
@@ -361,9 +363,9 @@ describe('layersManager', () => {
       await expect(action).toResolve();
       const result = await MockConfigProvider.getJson();
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      expect(result.caches[mockLayerName].format).toBe(TileFormat.JPEG);
+      expect(result.caches[mockLayerName].format).toBe(expectedTileMimeFormatJpeg);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      expect(result.caches[mockRedisLayerName].format).toBe(TileFormat.JPEG);
+      expect(result.caches[mockRedisLayerName].format).toBe(expectedTileMimeFormatJpeg);
       expect(updateJsonMock).toHaveBeenCalledTimes(1);
     });
 


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

@mapcolonies/types package is now implemented and provides this service:

lookup function that converts image type into associated mime.
mc-models-types was upgraded to support the new type of TileMimeFormat (image/png | image/jpeg)