### PR TITLE
helm: extract sub tiles path env from config provider if statement

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -105,11 +105,11 @@ spec:
             {{- if eq (upper $storage.mapproxyConfigProvider) "FS" }}
             - name: MAPPROXY_YAML_FILE_PATH  
               value: /configSource/mapproxy.yaml
-            - name: SUB_TILES_PATH
-              value: {{ $fs.internalPvc.tilesSubPath }}
             {{- end }} 
             - name: INTERNAL_MOUNT_DIR
               value: {{ .Values.env.internalMountDir }}
+            - name: SUB_TILES_PATH
+              value: {{ $fs.internalPvc.tilesSubPath }}
             {{- if eq (upper $storage.mapproxyConfigProvider) "DB" }}
             - name: DB_USER
               valueFrom:


### PR DESCRIPTION
Extract SUB_TILES_PATH env key from mapproxy config provider "if" statement 

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

