### PR TITLE
fix: mclabels partOf key

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -36,7 +36,7 @@ global:
 mclabels:
   #environment: development
   component: backend
-  partof: ingestion
+  partOf: ingestion
   owner: raster
   gisDomain: raster
   prometheus:


### PR DESCRIPTION
fixed mclabels key name "partof" -> "partOf"

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

