### PR TITLE
feat!: handle qouted numeric values for yaml parse (MAPCO-10069)

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -22,8 +22,9 @@ export function convertYamlToJson(yamlContent: string): IMapProxyJsonDocument {
 
 // read json object and convert it into a yaml content
 export function convertJsonToYaml(jsonDocument: IMapProxyJsonDocument): string {
-  const yamlContent: string = safeDump(jsonDocument, { noArrayIndent: true });
-  return yamlContent;
+  const yamlContent: string = safeDump(jsonDocument, { noArrayIndent: true, noCompatMode: true });
+  // post-process: unquote numeric-looking string keys (e.g. '404': → 404:)
+  return yamlContent.replace(/^(\s*)['"](\d+)['"]\s*:/gm, '$1$2:');
 }
 
 // write new content in mapproxy yaml config file

--- a/tests/unit/configs/common/utils.spec.ts
+++ b/tests/unit/configs/common/utils.spec.ts
@@ -56,6 +56,26 @@ describe('utils', () => {
       expect(typeof convertedYaml).toBe('string');
       expect(safeDumpStub).toHaveBeenCalledTimes(1);
     });
+
+    it('should output numeric values without quotes (noCompatMode)', function () {
+      // mock - json document with numeric values, a YAML 1.1 boolean-like string, and a numeric string key
+      const jsonDoc = { '404': { test: 'value' }, minZoom: 0, maxZoom: 18, epsg: 4326, status: 'yes' } as unknown as IMapProxyJsonDocument;
+      // action
+      const convertedYaml: string = utils.convertJsonToYaml(jsonDoc);
+      // expectation - numeric string key '404' must appear unquoted
+      expect(convertedYaml).toMatch(/404:/);
+      expect(convertedYaml).not.toMatch(/['"]404['"]\s*:/);
+      // expectation - numeric values must appear as plain scalars (no quotes)
+      expect(convertedYaml).toMatch(/minZoom: 0/);
+      expect(convertedYaml).toMatch(/maxZoom: 18/);
+      expect(convertedYaml).toMatch(/epsg: 4326/);
+      expect(convertedYaml).not.toMatch(/minZoom: ['"](\d+)['"]/);
+      expect(convertedYaml).not.toMatch(/maxZoom: ['"](\d+)['"]/);
+      expect(convertedYaml).not.toMatch(/epsg: ['"](\d+)['"]/);
+      // expectation - YAML 1.1 boolean alias 'yes' must not be quoted (noCompatMode: true)
+      expect(convertedYaml).toMatch(/status: yes/);
+      expect(convertedYaml).not.toMatch(/status: ['"](yes)['"]/);
+    });
   });
 
   describe('#replaceYamlFileContent', () => {


### PR DESCRIPTION
This pull request improves the conversion of JSON documents to YAML format to produce cleaner, more standards-compliant output and adds corresponding unit tests to verify the new behavior. The main changes focus on ensuring numeric string keys and values are not quoted and disabling YAML compatibility mode for better handling of certain value types.

Enhancements to YAML conversion:

* Updated `convertJsonToYaml` in `src/common/utils.ts` to use `noCompatMode: true` with `safeDump` and added post-processing to remove quotes from numeric string keys in the output YAML.

Expanded unit test coverage:

* Added a new test in `tests/unit/configs/common/utils.spec.ts` to verify that numeric string keys, numeric values, and YAML 1.1 boolean-like strings are correctly output without quotes when converting JSON to YAML.

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✔                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✖                                                                       |


